### PR TITLE
API Line Item field handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,4 +47,4 @@ tokio = { version = "1", default-features = false, features = [
     "rt-multi-thread",
 ] }
 anyhow = "1"
-tracing-subscriber = "0.2"
+tracing-subscriber = { version = "0.3", features = ["env-filter"]}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xero-rs"
-version = "0.0.4-alpha.2"
+version = "0.0.5-alpha.1"
 edition = "2018"
 description = "A Xero API client library for Rust"
 license-file = "LICENSE"

--- a/examples/accounting.rs
+++ b/examples/accounting.rs
@@ -3,6 +3,7 @@ extern crate tracing;
 
 use anyhow::Result;
 use xero_rs::KeyPair;
+use xero_rs::invoice::ListParameters;
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -14,7 +15,7 @@ async fn main() -> Result<()> {
     let connections = xero_rs::connection::list(&client).await?;
     info!("found client connections: {:#?}", connections);
 
-    let invoices = xero_rs::invoice::list(&client).await?;
+    let invoices = xero_rs::invoice::list(&client, ListParameters::default()).await?;
     info!("found invoices: {:#?}", invoices);
 
     Ok(())

--- a/examples/code_flow_authorization.rs
+++ b/examples/code_flow_authorization.rs
@@ -9,6 +9,7 @@ use serde::Deserialize;
 use tokio::sync::Mutex;
 use url::Url;
 use warp::Filter;
+use xero_rs::invoice::ListParameters;
 use xero_rs::KeyPair;
 
 lazy_static::lazy_static! {
@@ -69,7 +70,7 @@ async fn main() -> Result<()> {
         connections.first().expect("no connections found").tenant_id,
     ));
 
-    let invoices = xero_rs::invoice::list(&client).await?;
+    let invoices = xero_rs::invoice::list(&client, ListParameters::default()).await?;
     info!("found invoices: {:#?}", invoices);
 
     Ok(())

--- a/src/entities/invoice.rs
+++ b/src/entities/invoice.rs
@@ -249,5 +249,5 @@ pub async fn post_attachment(
         info!("Failed to upload attachment. Status: {}", response.status());
     }
 
-    Ok(response.json::<Value>().await.unwrap())
+    Ok(response.json::<Value>().await?)
 }

--- a/src/entities/line_item.rs
+++ b/src/entities/line_item.rs
@@ -5,6 +5,8 @@ use uuid::Uuid;
 #[derive(Clone, Copy, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 pub enum LineAmountType {
+    #[serde(alias = "NONE")]
+    None,
     #[serde(alias = "EXCLUSIVE")]
     Exclusive,
     #[serde(alias = "INCLUSIVE")]
@@ -15,30 +17,60 @@ pub enum LineAmountType {
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "PascalCase")]
+pub struct ItemSummary {
+    #[serde(rename = "ItemID")]
+    pub item_id: Uuid,
+    pub name: String,
+    pub code: String,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct TrackingSummary {
+    pub name: String,
+    pub option: String,
+    #[serde(rename = "TrackingCategoryID")]
+    pub tracking_category_id: Uuid,
+    #[serde(rename = "TrackingOptionID")]
+    pub tracking_option_id: Option<Uuid>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
 pub struct LineItem {
-    pub description: String,
-    pub quantity: Decimal,
-    pub unit_amount: Decimal,
-    pub item_code: Option<String>,
-    pub account_code: Option<String>,
     #[serde(rename = "LineItemID")]
     pub line_item_id: Uuid,
-    pub tax_type: String,
+    pub description: String,
+    pub quantity: Option<Decimal>,
+    pub unit_amount: Option<Decimal>,
+    pub item_code: Option<String>,
+    pub account_code: Option<String>,
+    #[serde(rename = "AccountID")]
+    pub account_id: Option<Uuid>,
+    pub item: Option<ItemSummary>,
+    pub tracking: Vec<TrackingSummary>,
+    pub tax_type: Option<String>,
     pub tax_amount: Decimal,
-    pub line_amount: Decimal,
+    pub line_amount: Option<Decimal>,
     pub discount_rate: Option<Decimal>,
-    // tracking
+    pub discount_amount: Option<Decimal>
 }
 
 impl LineItem {
     #[must_use]
     pub fn into_builder(self) -> Builder {
-        let mut builder = Builder::new(self.description, self.quantity, self.unit_amount);
+        let mut builder = Builder::new();
+        builder.description = Some(self.description);
+        builder.quantity = self.quantity;
+        builder.unit_amount = self.unit_amount;
         builder.item_code = self.item_code;
         builder.account_code = self.account_code;
-        builder.tax_type = self.tax_type;
-        builder.discount_rate = self.discount_rate;
         builder.line_item_id = Some(self.line_item_id);
+        builder.tax_type = self.tax_type;
+        builder.line_amount = self.line_amount;
+        builder.discount_rate = self.discount_rate;
+        builder.discount_amount = self.discount_amount;
+        builder.tracking = Some(self.tracking);
 
         builder
     }
@@ -47,25 +79,24 @@ impl LineItem {
 #[derive(Default, Debug, Serialize, Clone)]
 #[serde(rename_all = "PascalCase")]
 pub struct Builder {
-    pub description: String,
-    pub quantity: Decimal,
-    pub unit_amount: Decimal,
+    pub description: Option<String>,
+    pub quantity: Option<Decimal>,
+    pub unit_amount: Option<Decimal>,
     pub item_code: Option<String>,
     pub account_code: Option<String>,
-    pub tax_type: String,
-    pub discount_rate: Option<Decimal>,
-    // tracking
     #[serde(rename = "LineItemID")]
     pub line_item_id: Option<Uuid>,
+    pub tax_type: Option<String>,
+    pub line_amount: Option<Decimal>,
+    pub discount_rate: Option<Decimal>,
+    pub discount_amount: Option<Decimal>,
+    pub tracking: Option<Vec<TrackingSummary>>,
 }
 
 impl Builder {
     #[must_use]
-    pub fn new(description: String, quantity: Decimal, unit_amount: Decimal) -> Self {
+    pub fn new() -> Self {
         Builder {
-            description,
-            quantity,
-            unit_amount,
             ..Self::default()
         }
     }

--- a/src/entities/quote.rs
+++ b/src/entities/quote.rs
@@ -47,7 +47,7 @@ pub struct Quote {
     pub quote_number: String,
     pub reference: Option<String>,
     pub branding_theme_id: Option<Uuid>,
-    pub title: String,
+    pub title: Option<String>,
     pub summary: Option<String>,
     pub terms: Option<String>,
 }

--- a/tests/invoice.rs
+++ b/tests/invoice.rs
@@ -2,6 +2,7 @@
 extern crate tracing;
 
 use anyhow::Result;
+use xero_rs::invoice::ListParameters;
 use xero_rs::KeyPair;
 
 #[tokio::test]
@@ -12,7 +13,7 @@ async fn get_invoices() -> Result<()> {
         .init();
     let client = xero_rs::Client::from_client_credentials(KeyPair::from_env(), None).await?;
 
-    let invoices = xero_rs::invoice::list(&client, vec![]).await?;
+    let invoices = xero_rs::invoice::list(&client, ListParameters::default()).await?;
     debug!("found {:?} invoices", invoices.len());
 
     let invoice_from_list = invoices.first().unwrap();

--- a/tests/purchase_order.rs
+++ b/tests/purchase_order.rs
@@ -32,7 +32,7 @@ async fn get_purchase_orders() -> Result<()> {
 
     let purchase_order_from_list = purchase_orders.first().unwrap();
     let purchase_order =
-        xero_rs::purchase_order::get(&client, purchase_order_from_list.purchase_order_id).await?;
+        purchase_order::get(&client, purchase_order_from_list.purchase_order_id).await?;
     assert_eq!(
         purchase_order_from_list.purchase_order_id,
         purchase_order.purchase_order_id
@@ -55,17 +55,19 @@ async fn create_purchase_order() -> Result<()> {
     let description = "test description";
     let quantity = dec!(3.00);
     let unit_amount = dec!(2.00);
-    let line_items: Vec<line_item::Builder> = vec![line_item::Builder::new(
-        description.to_string(),
-        quantity,
-        unit_amount,
-    )];
+    let mut line_item = line_item::Builder::new();
+
+    line_item.description = Some(description.into());
+    line_item.quantity = Some(quantity.into());
+    line_item.unit_amount = Some(unit_amount.into());
+
+    let line_items = vec![line_item];
 
     let po_builder =
         purchase_order::Builder::new(ContactIdentifier::ID(contact.contact_id), line_items);
     let created_po = purchase_order::create(&client, &po_builder).await?;
 
-    let po = xero_rs::purchase_order::get(&client, created_po.purchase_order_id).await?;
+    let po = purchase_order::get(&client, created_po.purchase_order_id).await?;
     assert_eq!(created_po.purchase_order_id, po.purchase_order_id);
 
     Ok(())


### PR DESCRIPTION
As per issue #8 .

This update aims to increase flexibility of the line_item entity by marking most of the fields optional to work across varying tenants. The builder is now a list of optional fields, therefore the constructor has changed.

Test have been updated to align with the changes